### PR TITLE
for action don't click combobox if list is already visible

### DIFF
--- a/src/main/java/org/robotframework/swing/combobox/ComboBoxOperator.java
+++ b/src/main/java/org/robotframework/swing/combobox/ComboBoxOperator.java
@@ -136,11 +136,16 @@ public class ComboBoxOperator extends IdentifierSupport implements
 
     private abstract class ComboboxAction {
         public Object execute() {
+            boolean isOpenWhenWeStart = comboboxOperator.isPopupVisible();
             try {
-                comboboxOperator.pushComboButton();
+                if (!isOpenWhenWeStart) {
+                    comboboxOperator.pushComboButton();
+                }
                 return executeWhenComboBoxOpen();
             } finally {
-                comboboxOperator.hidePopup();
+                if (!isOpenWhenWeStart) {
+                    comboboxOperator.hidePopup();
+                }
                 SwingWaiter.waitToAvoidInstability(200);
             }
         }

--- a/src/test/java/org/robotframework/swing/combobox/ComboBoxOperatorSpec.java
+++ b/src/test/java/org/robotframework/swing/combobox/ComboBoxOperatorSpec.java
@@ -30,9 +30,10 @@ public class ComboBoxOperatorSpec extends Specification<ComboBoxOperator> {
             
             specify(context.getSource(), source);
         }
-        
+
         public void selectsItemWithName() {
             checking(new Expectations() {{
+                one(jComboboxOperator).isPopupVisible();
                 one(jComboboxOperator).pushComboButton();
                 one(jComboboxOperator).getVerification(); will(returnValue(true));
                 one(jComboboxOperator).setVerification(false);
@@ -44,19 +45,21 @@ public class ComboBoxOperatorSpec extends Specification<ComboBoxOperator> {
             }
 
             private void expectSelectionVerification() {
+                one(jComboboxOperator).isPopupVisible();
                 one(jComboboxOperator).pushComboButton();
                 one(jComboboxOperator).getTimeouts();
                 one(jComboboxOperator).getSelectedIndex();
                 one(textExtractor).getTextFromRenderedComponent(0); will(returnValue(comboItemIdentifier));
                 one(jComboboxOperator).hidePopup();
             }});
-            
+
             context.selectItem(comboItemIdentifier);
         }
-        
+
         public void selectsItemWithIndex() {
             final int index = 0;
             checking(new Expectations() {{
+                one(jComboboxOperator).isPopupVisible();
                 one(jComboboxOperator).pushComboButton();
                 one(jComboboxOperator).getVerification();  will(returnValue(true));
                 one(jComboboxOperator).setVerification(false);
@@ -64,47 +67,49 @@ public class ComboBoxOperatorSpec extends Specification<ComboBoxOperator> {
                 one(jComboboxOperator).hidePopup();
                 expectSelectionVerification();
             }
-            
+
             private void expectSelectionVerification() {
                 one(jComboboxOperator).getTimeouts();
                 one(jComboboxOperator).getSelectedIndex(); will(returnValue(new Integer(index)));
             }});
-            
+
             context.selectItem(""+index);
         }
-        
+
         public void getsSelectedItem() {
             final int index = 7;
             final Object selectedItem = "Fooness";
             checking(new Expectations() {{
+                one(jComboboxOperator).isPopupVisible();
                 one(jComboboxOperator).pushComboButton();
                 one(jComboboxOperator).getSelectedIndex(); will(returnValue(index));
                 one(textExtractor).getTextFromRenderedComponent(index); will(returnValue(selectedItem));
                 one(jComboboxOperator).hidePopup();
             }});
-            
+
             specify(context.getSelectedItem(), selectedItem);
         }
-        
+
         public void getItemEnabledState() {
             checking(new Expectations() {{
                 one(jComboboxOperator).isEnabled(); will(returnValue(false));
             }});
-            
+
             specify(context.isEnabled(), false);
         }
-        
+
         public void typesText() {
             checking(new Expectations() {{
                 one(jComboboxOperator).clearText();
                 one(jComboboxOperator).typeText("someText");
             }});
-            
+
             context.typeText("someText");
         }
-        
+
         public void getsValues() {
             checking(new Expectations() {{
+                one(jComboboxOperator).isPopupVisible();
                 one(jComboboxOperator).pushComboButton();
                 String[] items = new String[]{"one", "two", "three"};
                 one(textExtractor).itemCount(); will(returnValue(items.length));
@@ -113,7 +118,7 @@ public class ComboBoxOperatorSpec extends Specification<ComboBoxOperator> {
                 }
                 one(jComboboxOperator).hidePopup();
             }});
-            
+
             specify(context.getValues(), containsExactly("one", "two", "three"));
         }
     }


### PR DESCRIPTION
this is necessary for selecting items in column headers with dropdown menu.
general use case is that some custom controls may add dynamically dropdown component in expended state after certain item is clicked, so this dropdown list only exists in extended state. before this patch dropdown related keywords only work correctly when dropdown component is collapsed when calling the keyword. now it works if it is either collapsed or expanded.