### PR TITLE
add optional parameter `source` to Get Table Cell Value Keyword

### DIFF
--- a/src/main/java/org/robotframework/swing/keyword/table/TableKeywords.java
+++ b/src/main/java/org/robotframework/swing/keyword/table/TableKeywords.java
@@ -16,6 +16,7 @@
 
 package org.robotframework.swing.keyword.table;
 
+import java.awt.*;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -29,8 +30,10 @@ import org.robotframework.javalib.annotation.RobotKeywords;
 import org.robotframework.swing.common.IdentifierSupport;
 import org.robotframework.swing.comparator.EqualsStringComparator;
 import org.robotframework.swing.factory.OperatorFactory;
+import org.robotframework.swing.table.CellValueExtractor;
 import org.robotframework.swing.table.TableOperator;
 import org.robotframework.swing.table.TableOperatorFactory;
+
 
 @RobotKeywords
 public class TableKeywords extends IdentifierSupport {
@@ -113,22 +116,49 @@ public class TableKeywords extends IdentifierSupport {
     }
 
     @RobotKeyword("Returns cell's value from a table.\n\n"
-            + "Starting from SwingLibrary 1.1.4, value from cell rendered with check box is string true/false.\n\n"
+            + "Starting from SwingLibrary 1.1.4, value from cell rendered with check box is string true/false.\n"
+            + "Optional parameter _source_ allows to override text extraction strategy. "
+            + "Available values are _auto_ (default, will try to get text from cell component"
+            + "first and then from table model) and _model_ (will only try to get text from table model).\n\n"
             + "Example:\n"
             + "| ${cellValue}=   | Get Table Cell Value | _myTable_ | _0_            | _2_ |\n"
             + "| Should Be Equal | _tuesday_            |           | _${cellValue}_ |     |\n")
-    @ArgumentNames({"identifier", "row", "columnIdentifier"})
+    @ArgumentNames({"identifier", "row", "columnIdentifier", "source=auto"})
+    public String getTableCellValue(String identifier, String row, String columnIdentifier, String source) {
+        TableOperator operator = createTableOperator(identifier);
+        Component component = operator.getSource();
+        CellValueExtractor.TextSource textSource = textExtractionSourceFromText(source);
+        return operator.getCellValue(row, columnIdentifier, textSource);
+    }
+
+    private CellValueExtractor.TextSource textExtractionSourceFromText(String text) {
+        if (text.toLowerCase().equals("model"))
+            return CellValueExtractor.TextSource.MODEL;
+        else
+            return CellValueExtractor.TextSource.AUTO;
+    }
+
+    @RobotKeywordOverload
     public String getTableCellValue(String identifier, String row, String columnIdentifier) {
-        return createTableOperator(identifier).getCellValue(row, columnIdentifier).toString();
+        return getTableCellValue(identifier, row, columnIdentifier, "auto");
     }
 
     @RobotKeyword("Returns selected cell's value from a table.\n\n"
+            + "Optional parameter _source_ allows to override text extraction strategy. "
+            + "Available values are _auto_ (default, will try to get text from cell component"
+            + "first and then from table model) and _model_ (will only try to get text from table model).\n\n"
             + "Example:\n"
             + "| ${cellValue}=   | Get Selected Table Cell Value   | _myTable_      |\n"
             + "| Should Be Equal | _tuesday_                       | _${cellValue}_ |\n")
-    @ArgumentNames({"identifier"})
+    @ArgumentNames({"identifier", "source=auto"})
+    public Object getSelectedTableCellValue(String identifier, String source) {
+        CellValueExtractor.TextSource textSource = textExtractionSourceFromText(source);
+        return createTableOperator(identifier).getSelectedCellValue(textSource).toString();
+    }
+
+    @RobotKeywordOverload
     public Object getSelectedTableCellValue(String identifier) {
-        return createTableOperator(identifier).getSelectedCellValue().toString();
+        return getSelectedTableCellValue(identifier, "auto");
     }
 
     @RobotKeyword("Sets cell value in a table.\n\n"

--- a/src/main/java/org/robotframework/swing/table/CellValueExtractor.java
+++ b/src/main/java/org/robotframework/swing/table/CellValueExtractor.java
@@ -13,21 +13,42 @@ import org.robotframework.swing.chooser.WithText;
 import org.robotframework.swing.common.SmoothInvoker;
 
 public class CellValueExtractor {
+    public enum TextSource {AUTO, MODEL}
+
     private JTableOperator jTableOperator;
 
     public CellValueExtractor(JTableOperator jTableOperator) {
         this.jTableOperator = jTableOperator;
     }
 
+    public String textOf(int row, int col, TextSource source) {
+        if (source == TextSource.MODEL)
+            return getTextFromTableModel(row, col);
+        else
+            return getTextWithDefaultStrategy(row, col);
+    }
+
     public String textOf(int row, int col) {
+        return textOf(row, col, TextSource.AUTO);
+    }
+
+    public String getTextWithDefaultStrategy(int row, int col) {
         try {
-            Component cellRendererComponent = getCellRendererComponent(row, col);
-            if (isButtonBasedRenderer(cellRendererComponent))
-                return new Boolean(((AbstractButton) cellRendererComponent).isSelected()).toString();
-            return coerceToWithText(cellRendererComponent).getText();
+            return getTextFromCellComponent(row, col);
         } catch (AllMethodsNotImplementedException e) {
-            return wrapElementToWithText(row, col).getText();
+            return getTextFromTableModel(row, col);
         }
+    }
+
+    private String getTextFromTableModel(int row, int col) {
+        return wrapElementToWithText(row, col).getText();
+    }
+
+    private String getTextFromCellComponent(int row, int col) {
+        Component cellRendererComponent = getCellRendererComponent(row, col);
+        if (isButtonBasedRenderer(cellRendererComponent))
+            return new Boolean(((AbstractButton) cellRendererComponent).isSelected()).toString();
+        return coerceToWithText(cellRendererComponent).getText();
     }
 
     public Component getCellRendererComponent(int row, int column) {

--- a/src/main/java/org/robotframework/swing/table/TableOperator.java
+++ b/src/main/java/org/robotframework/swing/table/TableOperator.java
@@ -53,9 +53,9 @@ public class TableOperator extends IdentifierSupport implements
         return new TableHeaderOperator(jTableOperator.getHeaderOperator());
     }
 
-    public String getCellValue(String row, String columnIdentifier) {
+    public String getCellValue(String row, String columnIdentifier, CellValueExtractor.TextSource source) {
         Point cell = findCell(row, columnIdentifier);
-        return cellValueExtractor.textOf(cell.y, cell.x);
+        return cellValueExtractor.textOf(cell.y, cell.x, source);
     }
 
     public boolean isCellEditable(String row, String columnIdentifier) {
@@ -144,10 +144,14 @@ public class TableOperator extends IdentifierSupport implements
         return jTableOperator.findCellRow(text, col, 0);
     }
 
-    public Object getSelectedCellValue() {
+    public Object getSelectedCellValue(CellValueExtractor.TextSource source) {
         int selectedRow = jTableOperator.getSelectedRow();
         int selectedColumn = jTableOperator.getSelectedColumn();
-        return cellValueExtractor.textOf(selectedRow, selectedColumn);
+        return cellValueExtractor.textOf(selectedRow, selectedColumn, source);
+    }
+
+    public Object getSelectedCellValue() {
+        return getSelectedCellValue(CellValueExtractor.TextSource.AUTO);
     }
 
     public void callPopupMenuItemOnSelectedCells(String menuPath) {

--- a/src/main/java/org/robotframework/swing/testapp/TestApplication.java
+++ b/src/main/java/org/robotframework/swing/testapp/TestApplication.java
@@ -247,7 +247,7 @@ public class TestApplication {
                 {"column one", "one/one", "two/one", "three/one", "four/one"},
                 {"column two", "one/two", "two/two", "three/two", "four/two"},
                 {"column three", "one/three", "two/three", "three/three",
-                        "four/three"},
+                        "four/three!!!"},
                 {"column four", Boolean.TRUE, Boolean.TRUE, Boolean.FALSE,
                         Boolean.FALSE}};
     }

--- a/src/main/java/org/robotframework/swing/testapp/TestTable.java
+++ b/src/main/java/org/robotframework/swing/testapp/TestTable.java
@@ -16,6 +16,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
+import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
@@ -65,6 +66,9 @@ public class TestTable extends JScrollPane {
             }
         });
 
+        TableColumn col2 = table.getColumnModel().getColumn(2);
+        col2.setCellRenderer(new CustomRenderer());
+
         return table;
     }
 
@@ -77,6 +81,16 @@ public class TestTable extends JScrollPane {
                                                        boolean hasFocus, int row, int column) {
             setSelectedIndex(row);
             return this;
+        }
+    }
+
+    static class CustomRenderer extends DefaultTableCellRenderer {
+        public void setValue(Object value) {
+            String s = value.toString();
+            if (s.equals("four/three!!!"))
+                setText("four/three");
+            else
+                setText(s);
         }
     }
 

--- a/src/test/java/org/robotframework/swing/keyword/table/TableKeywordsSpec.java
+++ b/src/test/java/org/robotframework/swing/keyword/table/TableKeywordsSpec.java
@@ -16,6 +16,7 @@ import org.robotframework.jdave.contract.RobotKeywordsContract;
 import org.robotframework.jdave.mock.MockSupportSpecification;
 import org.robotframework.swing.comparator.EqualsStringComparator;
 import org.robotframework.swing.factory.OperatorFactory;
+import org.robotframework.swing.table.CellValueExtractor;
 import org.robotframework.swing.table.TableOperator;
 
 
@@ -128,7 +129,7 @@ public class TableKeywordsSpec extends MockSupportSpecification<TableKeywords> {
 
         public void getsSelectedTableCellValue() {
             checking(new Expectations() {{
-                one(tableOperator).getSelectedCellValue();
+                one(tableOperator).getSelectedCellValue(CellValueExtractor.TextSource.AUTO);
                 will(returnValue(cellValue));
             }});
 

--- a/src/test/resources/robot-tests/tablekeywords.txt
+++ b/src/test/resources/robot-tests/tablekeywords.txt
@@ -92,9 +92,18 @@ Get Selected Table Cell Value
     ${cellValue}=  getSelectedTableCellValue  ${tableName}
     shouldBeEqual  four/three  ${cellValue}
 
+Get Selected Table Cell Value From Model
+    selectTableCell  ${tableName}  3  2
+    ${cellValue}=  getSelectedTableCellValue  ${tableName}  source=MODEL
+    shouldBeEqual  four/three!!!  ${cellValue}
+
 Get Table Cell Value By Index
-    ${cellValue}=  getTableCellValue  ${tableName}  2  1
-    shouldBeEqual  three/two  ${cellValue}
+    ${cellValue}=  getTableCellValue  ${tableName}  3  2
+    shouldBeEqual  four/three  ${cellValue}
+
+Get Table Cell Value From Model By Index
+    ${cellValue}=  getTableCellValue  ${tableName}  3  2  source=MODEL
+    shouldBeEqual  four/three!!!  ${cellValue}
 
 Clear Table Cell
     clearTableCell  ${tableName}  2  1
@@ -131,13 +140,13 @@ Get Table Row Count By Name
 Find Table Row
     ${row}=  findTableRow  ${tableName}  one/one
     shouldBeEqualAsIntegers  0  ${row}
-    ${row}=  findTableRow  ${tableName}  four/three
+    ${row}=  findTableRow  ${tableName}  four/three!!!
     shouldBeEqualAsIntegers  3  ${row}
 
 Find Table Row With Column
     ${row}=  findTableRow  ${tableName}  one/one  column one
     shouldBeEqualAsIntegers  0  ${row}
-    ${row}=  findTableRow  ${tableName}  four/three  column three
+    ${row}=  findTableRow  ${tableName}  four/three!!!  column three
     shouldBeEqualAsIntegers  3  ${row}
     ${row}=  findTableRow  TableWithSingleValue  foo
     shouldBeEqualAsIntegers  0  ${row}


### PR DESCRIPTION
When source is set to "model", text extractor won't try to get text from cell's component firsts and will get it directly from table model. When source is set to "auto" (default) old strategy is used, i.e. extractor will first try to extract text from cell's component and then if this fails it will get it from table model.