### PR TITLE
Tree Node Popup Menu Item Should Be Enabled/Disabled keywords problem #94

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     </dependency>
   </dependencies>
   <build>
-    <directory>${project.basedir}/target</directory>
+    <directory>${project.basedir}/target with spaces</directory>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     </dependency>
   </dependencies>
   <build>
-    <directory>${project.basedir}/target with spaces</directory>
+    <directory>${project.basedir}/target</directory>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -198,6 +198,7 @@
               <includes>
                 <include>org.netbeans:jemmy</include>
                 <include>abbot:abbot</include>
+                <include>abbot:costello</include>
                 <include>junit:junit</include>
                 <include>gnu-regexp:gnu-regexp</include>
                 <include>org.jretrofit:jretrofit</include>


### PR DESCRIPTION
Added a missing dependency to pom.xml when building the jar file, because Tree Node Popup Menu Item Should Be Enabled/Disable keywords were throwing an exception.