### PR TITLE
add support for complex objects in Get List Values

### DIFF
--- a/src/main/java/org/robotframework/swing/list/ListOperator.java
+++ b/src/main/java/org/robotframework/swing/list/ListOperator.java
@@ -102,7 +102,7 @@ public class ListOperator extends IdentifierSupport implements ComponentWrapper 
 		ListModel model = jListOperator.getModel();
 		List<String> items = new ArrayList<String>();
 		for (int i = 0, itemCount = model.getSize(); i < itemCount; i++)
-			items.add((String)model.getElementAt(i));
+			items.add(String.valueOf(model.getElementAt(i)));
 		return items;
 	}
 }


### PR DESCRIPTION
PR for #103.
Used `String.valueOf(obj)` instead of proposed `obj.toString()`to handle null occurrence gracefully. 