### PR TITLE
Change find table row keyword to accept indexes too

### DIFF
--- a/src/main/java/org/robotframework/swing/keyword/table/TableKeywords.java
+++ b/src/main/java/org/robotframework/swing/keyword/table/TableKeywords.java
@@ -204,7 +204,8 @@ public class TableKeywords extends IdentifierSupport {
             + "Examples:\n"
             + "| ${row}= | `Find Table Row` | myTable | Some Value |\n"
             + "| `Select From Table Cell Popup Menu` | myTable | ${row} | 2 | Activate |\n"
-            + "| ${row}= | `Find Table Row` | myTable | Some Value | Some Column | # Searches the 'Some Value' from the specified  'Some Column'  | \n")
+            + "| ${row}= | `Find Table Row` | myTable | Some Value | Some Column | # Searches the 'Some Value' from the specified  'Some Column'  | \n"
+            + "| ${row}= | `Find Table Row` | myTable | Some Value | 0 | # Searches the 'Some Value' from the column with index 0 | \n")
     @ArgumentNames({"identifier", "text", "columnIdentifier="})
     public int findTableRow(String identifier, String text, String columnIdentifier) {
         if (columnIdentifier != null && !"".equals(columnIdentifier))

--- a/src/main/java/org/robotframework/swing/table/TableOperator.java
+++ b/src/main/java/org/robotframework/swing/table/TableOperator.java
@@ -139,8 +139,13 @@ public class TableOperator extends IdentifierSupport implements
     public int findCellRow(String text, String columnIdentifier) {
         int col = jTableOperator.findColumn(columnIdentifier);
         if (col == -1)
-            throw new RuntimeException("Column '" + columnIdentifier
+            try {
+                columnIdentifier = jTableOperator.getColumnName(Integer.parseInt(columnIdentifier));
+                col = jTableOperator.findColumn(columnIdentifier);
+            } catch (RuntimeException e) {
+                throw new RuntimeException("Column '" + columnIdentifier
                     + " not found.");
+            }
         return jTableOperator.findCellRow(text, col, 0);
     }
 

--- a/src/test/resources/robot-tests/table.robot
+++ b/src/test/resources/robot-tests/table.robot
@@ -155,6 +155,10 @@ Find Table Row With Column
     ${row}=  findTableRow  TableWithSingleValue  foo  column two
     shouldBeEqualAsIntegers  1  ${row}
 
+Find Table Row With Column Identifier As Index
+    ${row}=  findTableRow  ${tableName}  one/one  0
+    shouldBeEqualAsIntegers  0  ${row}
+
 Get Table Row Count By Index
     ${rowCount}=  getTableRowCount  0
     shouldBeEqualAsIntegers  4  ${rowCount}


### PR DESCRIPTION
This PR modifies `Find Table Row` so it would allow to search the row using index for column identifier.