### PR TITLE
Radio button menu item

### DIFF
--- a/src/main/java/org/robotframework/swing/keyword/menu/MenuRadioButtonKeywords.java
+++ b/src/main/java/org/robotframework/swing/keyword/menu/MenuRadioButtonKeywords.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2008-2011 Nokia Siemens Networks Oyj
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.robotframework.swing.keyword.menu;
+
+import org.junit.Assert;
+
+import org.netbeans.jemmy.operators.JMenuItemOperator;
+import org.netbeans.jemmy.operators.JRadioButtonMenuItemOperator;
+import org.robotframework.javalib.annotation.ArgumentNames;
+import org.robotframework.javalib.annotation.RobotKeyword;
+import org.robotframework.javalib.annotation.RobotKeywords;
+import org.robotframework.swing.keyword.window.WindowKeywords;
+import org.robotframework.swing.menu.MenuSupport;
+
+import javax.swing.JRadioButtonMenuItem;
+
+@RobotKeywords
+public class MenuRadioButtonKeywords extends MenuSupport {
+    private WindowKeywords windowKeywords = new WindowKeywords();
+
+    @RobotKeyword("Searches for an radio menu item from the menu of the currently selected window "
+            + "and fails if it is not checked.\n\n"
+            + "Example:\n"
+            + "| `Menu Item Should Be Selected` | Tools|My RadioItem |\n")
+    @ArgumentNames({"menuPath"})
+    public void radioMenuItemShouldBeSelected(String menuPath) {
+        Assert.assertTrue("Menu item '" + menuPath + "' is not selected.", showRadioMenuItem(menuPath).isSelected());
+    }
+
+    @RobotKeyword("Searches for an radio menu item from the menu of the currently selected window "
+            + "and fails if it is selected.\n\n"
+            + "Example:\n"
+            + "| `Menu Item Should Not Be Selected` | Tools|My RadioItem |\n")
+    @ArgumentNames({"menuPath"})
+    public void radioMenuItemShouldNotBeSelected(String menuPath) {
+        Assert.assertFalse("Menu item '" + menuPath + "' is selected.", showRadioMenuItem(menuPath).isSelected());
+    }
+
+    private JRadioButtonMenuItemOperator showRadioMenuItem(String path){
+        JMenuItemOperator menuItemOperator = super.showMenuItem(path);
+        return new JRadioButtonMenuItemOperator((JRadioButtonMenuItem) menuItemOperator.getSource());
+    }
+}

--- a/src/main/java/org/robotframework/swing/keyword/menu/MenuRadioButtonKeywords.java
+++ b/src/main/java/org/robotframework/swing/keyword/menu/MenuRadioButtonKeywords.java
@@ -33,7 +33,7 @@ import javax.swing.JRadioButtonMenuItem;
 public class MenuRadioButtonKeywords extends MenuSupport {
     private WindowKeywords windowKeywords = new WindowKeywords();
 
-    @RobotKeyword("Searches for an radio menu item from the menu of the currently selected window "
+    @RobotKeyword("Searches for a radio menu item from the menu of the currently selected window "
             + "and fails if it is not checked.\n\n"
             + "Example:\n"
             + "| `Menu Item Should Be Selected` | Tools|My RadioItem |\n")
@@ -42,7 +42,7 @@ public class MenuRadioButtonKeywords extends MenuSupport {
         Assert.assertTrue("Menu item '" + menuPath + "' is not selected.", showRadioMenuItem(menuPath).isSelected());
     }
 
-    @RobotKeyword("Searches for an radio menu item from the menu of the currently selected window "
+    @RobotKeyword("Searches for a radio menu item from the menu of the currently selected window "
             + "and fails if it is selected.\n\n"
             + "Example:\n"
             + "| `Menu Item Should Not Be Selected` | Tools|My RadioItem |\n")

--- a/src/main/java/org/robotframework/swing/testapp/TestMenuBar.java
+++ b/src/main/java/org/robotframework/swing/testapp/TestMenuBar.java
@@ -3,12 +3,7 @@ package org.robotframework.swing.testapp;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
-import javax.swing.JCheckBoxMenuItem;
-import javax.swing.JFrame;
-import javax.swing.JMenu;
-import javax.swing.JMenuBar;
-import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
+import javax.swing.*;
 
 import org.robotframework.javalib.util.KeywordNameNormalizer;
 
@@ -58,6 +53,7 @@ public class TestMenuBar extends JMenuBar {
             });
 
             add(new JCheckBoxMenuItem("Test menu checkbox"));
+            add(new JRadioButtonMenuItem("Test menu radiobutton"));
             add(new TestMenuItem("Menu Item").setDisabled());
         }});
         add(new TestMenu("Test Menu2") {{

--- a/src/test/resources/robot-tests/menu.robot
+++ b/src/test/resources/robot-tests/menu.robot
@@ -3,11 +3,12 @@ Test Teardown   selectMainWindow
 Library         TestSwingLibrary
 
 *** Variables ***
-${menuText}  Test Menu
-${showDialog}  ${menuText}|Show Test Dialog
-${mutableMenu}  ${menuText}|Mutable Menu
-${disabledMenu}  ${menuText}|Disabled Menu Item
-${checkboxMenu}  Test menu checkbox
+${menuText}         Test Menu
+${showDialog}       ${menuText}|Show Test Dialog
+${mutableMenu}      ${menuText}|Mutable Menu
+${disabledMenu}     ${menuText}|Disabled Menu Item
+${checkboxMenu}     Test menu checkbox
+${radioButtonMenu}  Test menu radiobutton
 
 *** Test Cases ***
 Select From Main Menu
@@ -83,6 +84,16 @@ Main Menu Item Should Not Be Selected
     selectFromMainMenuAndWait  ${menuText}|${checkboxMenu}
     runKeywordAndExpectError  Menu item '${menuText}|${checkboxMenu}' is selected.  mainMenuItemShouldNotBeChecked  ${menuText}|${checkboxMenu}
     [Teardown]  selectFromMainMenuAndWait  ${menuText}|${checkboxMenu}
+
+Menu Radio Item Should Be Selected
+    selectFromMainMenuAndWait  ${menuText}|${radioButtonMenu}
+    radioMenuItemShouldBeSelected  ${menuText}|${radioButtonMenu}
+    [Teardown]  selectFromMainMenuAndWait  ${menuText}|${radioButtonMenu}
+
+Menu Radio Item Should Not Be Selected
+    selectFromMainMenuAndWait  ${menuText}|${radioButtonMenu}
+    runKeywordAndExpectError  Menu item '${menuText}|${radioButtonMenu}' is selected.  radioMenuItemShouldNotBeSelected  ${menuText}|${radioButtonMenu}
+    [Teardown]  selectFromMainMenuAndWait  ${menuText}|${radioButtonMenu}
 
 Select From Popup Menu
     selectFromPopupMenu  testTextField  Show name


### PR DESCRIPTION
Right now `SwingLibrary` has support only for checking if check boxes are checked or not, but this is not the case for radio button items. This PR aims to fix that by adding two new keywords `Radio Menu Item Should Be Selected` and `Radio Menu Item Should Not Be Selected`.