### PR TITLE
Replicated issue. Created Test for error handling.

### DIFF
--- a/src/main/java/org/robotframework/swing/testapp/TestApplication.java
+++ b/src/main/java/org/robotframework/swing/testapp/TestApplication.java
@@ -75,6 +75,7 @@ public class TestApplication {
     private void addComponentsToMainPanel() {
         panel.add(new TestTextField());
         panel.add(new TestButton());
+        panel.add(new TestNullPointerException());
         panel.add(new TestList());
         panel.add(new TestList() {
             {

--- a/src/main/java/org/robotframework/swing/testapp/TestNullPointerException.java
+++ b/src/main/java/org/robotframework/swing/testapp/TestNullPointerException.java
@@ -1,0 +1,26 @@
+package org.robotframework.swing.testapp;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.ActionEvent;
+
+import javax.swing.JButton;
+
+public class TestNullPointerException extends JButton {
+    private static final String INITIAL_TEXT = "Test NullPointerException";
+    private static final String BUTTON_PUSHED_TEXT = "Button Was Pushed";
+
+    public TestNullPointerException() {
+        super(INITIAL_TEXT);
+        setName("testNullPointer");
+        setToolTipText("testToolTip");
+        addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (e.getButton() == MouseEvent.BUTTON1)
+                    setText(BUTTON_PUSHED_TEXT + e.getClickCount());
+                    throw new NullPointerException("This is a test for null pointer exception");
+            }
+        });
+    }
+}

--- a/src/test/resources/robot-tests/nullpointerexception.robot
+++ b/src/test/resources/robot-tests/nullpointerexception.robot
@@ -1,0 +1,31 @@
+*** Settings ***
+Suite Setup     captureOriginalButtonText
+Test Setup      resetButton
+Library         TestSwingLibrary
+
+*** Variables ***
+${buttonName}  testButton
+${buttonText}  Test NullPointerException
+${toolTipText}  testToolTip
+${buttonTextAfterPush}  Button Was Pushed1
+${buttonIndex}  0
+
+*** Test Cases ***
+Report For NullPointerException
+    Run Keyword And Expect Error  *  pushButton  ${buttonText}
+    # buttonWasPushed  ${buttonName}
+
+*** Keywords ***
+buttonWasPushed
+    [Arguments]  ${buttonIdentifier}
+    ${buttonText}=  getButtonText  ${buttonIdentifier}
+    shouldBeEqual  ${buttonText}  ${buttonTextAfterPush}
+
+captureOriginalButtonText
+    ${text}=  getButtonText  ${buttonName}
+    setSuiteVariable  \${originalButtonText}  ${text}
+
+resetButton
+    setButtonText  ${buttonName}  ${originalButtonText}
+    enableButton  ${buttonName}
+


### PR DESCRIPTION
RF does not mark the Null Pointer Exception as an error, thus, the issue. #155 